### PR TITLE
IO Refactor: Save files

### DIFF
--- a/coda-prototype/initUI.js
+++ b/coda-prototype/initUI.js
@@ -437,89 +437,13 @@ function initUI(dataset) {
                 console.log("Exporting empty instrumentation file.");
             }
             let dataBlob = new Blob([activity], {type: 'application/json'});
-            // TODO: IO
-            chrome.downloads.download({url: window.URL.createObjectURL(dataBlob), saveAs: true}, function(dlId) {
-                console.log("Downloaded activity file with id: " + dlId);
-            });
+            FileIO.saveFile(dataBlob, downloadId => console.log("Downloaded activity file with id: " + downloadId));
         });
     });
 
-    // TODO: IO
-    $("#export-dataset").click(() => {
+    $("#export-dataset").click(() => FileIO.saveDataset(newDataset));
 
-        let eventJSON = {"data": [], "fields" : ["id", "timestamp", "owner", "data", "schemeId", "schemeName", "deco_codeValue", "deco_codeId", "deco_confidence", "deco_manual", "deco_timestamp", "deco_author"]};
-        for (let event of newDataset.events.values()) {
-            for (let schemeKey of Object.keys(newDataset.schemes)) {
-                let newEventData = [];
-                newEventData.push(event.name);
-                newEventData.push(event.timestamp);
-                newEventData.push(event.owner);
-                newEventData.push(event.data);
-                newEventData.push(schemeKey);
-                newEventData.push(newDataset.schemes[schemeKey].name);
-
-                if (event.decorations.has(schemeKey)) {
-                    let deco = event.decorations.get(schemeKey);
-                    if (deco.code != null) {
-                        newEventData.push(deco.code.value);
-                        newEventData.push(deco.code.id);
-                    } else {
-                        newEventData.push("");
-                        newEventData.push("");
-                    }
-                    newEventData.push(deco.confidence);
-                    newEventData.push(deco.manual);
-                    newEventData.push((deco.timestamp) ? deco.timestamp : "");
-                    newEventData.push("");
-                } else {
-                    newEventData.push("");
-                    newEventData.push("");
-                    newEventData.push("");
-                    newEventData.push("");
-                    newEventData.push("");
-                    newEventData.push("");
-                }
-                eventJSON["data"].push(newEventData);
-            }
-
-            if (Object.keys(newDataset.schemes).length === 0) {
-                let newEventData = [];
-                newEventData.push(event.name);
-                newEventData.push(event.timestamp);
-                newEventData.push(event.owner);
-                newEventData.push(event.data);
-                newEventData.push("");
-                newEventData.push("");
-                newEventData.push("");
-                newEventData.push("");
-                newEventData.push("");
-                newEventData.push("");
-                newEventData.push("");
-                newEventData.push("");
-
-                eventJSON["data"].push(newEventData);
-            }
-
-        }
-
-        let dataBlob = new Blob([Papa.unparse(eventJSON, {header:true, delimiter:";"})], {type: 'text/plain'});
-
-        // TODO: IO
-        // TODO: save an activity prior to attempting the download to record that an export was attempted?
-        chrome.downloads.download({url: window.URL.createObjectURL(dataBlob), saveAs: true}, function(dlId) {
-            console.log("Downloaded file with id: " + dlId);
-            storage.saveActivity({
-                "category": "DATASET",
-                "message": "Exported dataset",
-                "messageDetails": "", //todo identifier
-                "data": "",
-                "timestamp": new Date()
-            });
-        });
-    });
-
-    $("#dataset-file").on("change", event => { // Fires when the dataset file has been changed by the file chooser UI
-
+    $("#dataset-file").on("change", event => { // Fires when the dataset file has been changed by the file picker UI
         $(event.target).parents(".dropdown").removeClass("open");
 
         // hide alert
@@ -909,30 +833,7 @@ function initUI(dataset) {
 
     });
 
-
-    $("#scheme-download").on("click", () => {
-
-        let schemeJSON = {"data": [], "fields":["scheme_id", "scheme_name", "code_id", "code_value", "code_colour", "code_shortcut","code_words", "code_regex"]};
-        for (let [codeId, code] of tempScheme.codes) {
-            let codeArr = [tempScheme.id, tempScheme.name, codeId, code.value, code.color, code.shortcut, code.words.toString(), code.regex[0]];
-            schemeJSON["data"].push(codeArr);
-        }
-
-        // TODO: IO
-        let dataBlob = new Blob([Papa.unparse(schemeJSON, {header:true, delimiter:";"})], {type: 'text/plain'});
-        chrome.downloads.download({url: window.URL.createObjectURL(dataBlob), saveAs: true}, function(dlId) {
-            console.log("Downloaded file with id: " + dlId);
-
-            storage.saveActivity({
-                "category": "SCHEME",
-                "message": "Exported scheme",
-                "messageDetails": {"scheme": tempScheme.id},
-                "data": tempScheme.toJSON(),
-                "timestamp": new Date()
-            });
-
-        });
-    });
+    $("#scheme-download").on("click", () => FileIO.saveScheme(tempScheme));
 
     /*
     TOOLTIPS

--- a/coda-prototype/model.js
+++ b/coda-prototype/model.js
@@ -1542,6 +1542,123 @@ class StorageManager {
     }
 }
 StorageManager._MAX_ACTIVITY_SAVE_FREQ = 3;
+class FileIO {
+    /**
+     * Saves the given string to a file. The file is determined by a file selector UI.
+     * @param {Blob} fileContents Data to write to the file.
+     * @param {(downloadId: number) => void} onDownloadStartedHandler Function to run once the download has started
+     *                                                                successfully.
+     */
+    static saveFile(fileContents, onDownloadStartedHandler) {
+        let url = window.URL.createObjectURL(fileContents);
+        console.log("Saving file from URL", url);
+        chrome.downloads.download({
+            url: url,
+            saveAs: true
+        }, onDownloadStartedHandler);
+    }
+    /**
+     * Exports the given dataset to file on disk.
+     * @param {Dataset} dataset Dataset to save to disk.
+     */
+    static saveDataset(dataset) {
+        let eventJSON = { "data": [], "fields": ["id", "timestamp", "owner", "data", "schemeId", "schemeName", "deco_codeValue", "deco_codeId",
+                "deco_confidence", "deco_manual", "deco_timestamp", "deco_author"]
+        }; // TODO: why are rows being referred to as 'events'?
+        // For each 'event', add a row to the output for each scheme if schemes exist, or a single row if not.
+        // TODO: Write this in a less-yucky way such that pushing many empty strings is not required
+        for (let event of dataset.events.values()) {
+            if (Object.keys(dataset.schemes).length === 0) {
+                let newEventData = [];
+                newEventData.push(event.name);
+                newEventData.push(event.timestamp);
+                newEventData.push(event.owner);
+                newEventData.push(event.data);
+                newEventData.push(""); // schemeId
+                newEventData.push(""); // schemeName
+                newEventData.push(""); // deco_codeValue
+                newEventData.push(""); // deco_codeId
+                newEventData.push(""); // deco_confidence
+                newEventData.push(""); // deco_manual
+                newEventData.push(""); // deco_timestamp
+                newEventData.push(""); // deco_author
+                eventJSON["data"].push(newEventData);
+            }
+            else {
+                for (let schemeKey of Object.keys(dataset.schemes)) {
+                    let newEventData = [];
+                    newEventData.push(event.name);
+                    newEventData.push(event.timestamp);
+                    newEventData.push(event.owner);
+                    newEventData.push(event.data);
+                    newEventData.push(schemeKey);
+                    newEventData.push(dataset.schemes[schemeKey].name);
+                    if (event.decorations.has(schemeKey)) {
+                        // If this row has been coded under this scheme, include its coding
+                        let decoration = event.decorations.get(schemeKey);
+                        if (decoration.code != null) {
+                            newEventData.push(decoration.code.value);
+                            newEventData.push(decoration.code.id);
+                        }
+                        else {
+                            newEventData.push(""); // deco_codeValue
+                            newEventData.push(""); // deco_codeId
+                        }
+                        newEventData.push(decoration.confidence);
+                        newEventData.push(decoration.manual);
+                        newEventData.push((decoration.timestamp) ? decoration.timestamp : "");
+                        newEventData.push(""); // deco_author
+                    }
+                    else {
+                        newEventData.push(""); // deco_codeValue
+                        newEventData.push(""); // deco_codeId
+                        newEventData.push(""); // deco_confidence
+                        newEventData.push(""); // deco_manual
+                        newEventData.push(""); // deco_timestamp
+                        newEventData.push(""); // deco_author
+                    }
+                    eventJSON["data"].push(newEventData);
+                }
+            }
+        }
+        let dataBlob = new Blob([Papa.unparse(eventJSON, { header: true, delimiter: ";" })], { type: 'text/plain' });
+        FileIO.saveFile(dataBlob, downloadId => {
+            console.log("Downloaded file with id: " + downloadId);
+            storage.saveActivity({
+                "category": "DATASET",
+                "message": "Exported dataset",
+                "messageDetails": "",
+                "data": "",
+                "timestamp": new Date()
+            });
+        });
+    }
+    /**
+     * Exports the given code scheme to a file on disk.
+     * @param {CodeScheme} scheme Code scheme to save to disk.
+     */
+    static saveScheme(scheme) {
+        let schemeJSON = { "data": [], "fields": ["scheme_id", "scheme_name", "code_id", "code_value", "code_colour",
+                "code_shortcut", "code_words", "code_regex"]
+        };
+        for (let [codeId, code] of scheme.codes) {
+            let codeArr = [scheme.id, scheme.name, codeId, code.value, code.color,
+                code.shortcut, code.words.toString(), code.regex[0]];
+            schemeJSON["data"].push(codeArr);
+        }
+        let dataBlob = new Blob([Papa.unparse(schemeJSON, { header: true, delimiter: ";" })], { type: 'text/plain' });
+        FileIO.saveFile(dataBlob, downloadId => {
+            console.log("Downloaded file with id: " + downloadId);
+            storage.saveActivity({
+                "category": "SCHEME",
+                "message": "Exported scheme",
+                "messageDetails": { "scheme": scheme.id },
+                "data": scheme.toJSON(),
+                "timestamp": new Date()
+            });
+        });
+    }
+}
 class UndoManager {
     constructor() {
         this.pointer = 0;


### PR DESCRIPTION
Moves exporting of datasets and code schemes to a new FileIO class (with a bit of tidying along the way)

Will move import-from-file functions next; then propose moving FileIO and StorageManager to their own files.