### PR TITLE
#93 deploy script zip directory

### DIFF
--- a/coda-prototype/.gitignore
+++ b/coda-prototype/.gitignore
@@ -1,0 +1,3 @@
+.idea/
+node_modules/
+coda.zip

--- a/coda-prototype/deploy.sh
+++ b/coda-prototype/deploy.sh
@@ -3,7 +3,7 @@ set -e
 
 # Revert version.json on exit.
 function finish {
-    echo "{\"hash\": \"develop\", \"date\": \"\"}" >version.json
+    echo $'{\n  "hash": "develop",\n  "date": ""\n}' >version.json
 }
 trap finish EXIT
 

--- a/coda-prototype/version.json
+++ b/coda-prototype/version.json
@@ -2,4 +2,3 @@
   "hash": "develop",
   "date": ""
 }
-


### PR DESCRIPTION
Revised deploy script to use the file system version rather than HEAD, emitting a warning if HEAD does not match the directory version.

This closes #93 and closes #92 