### PR TITLE
#89: Scheme Update

### DIFF
--- a/coda-prototype/css/style.css
+++ b/coda-prototype/css/style.css
@@ -206,7 +206,7 @@ div[class*=col-], #message-panel {
 }
 
 #scheme-save-btn-group {
-    margin-left: 10px;
+    margin-left: 15px;
 }
 
 .panel-heading > h4, .panel-heading > span {
@@ -246,7 +246,11 @@ div[class*=col-], #message-panel {
     bottom: 50px;
     position: absolute;
     width: 100%;
-    padding: 10px 10px 0px 10px;
+    padding: 10px 10px 0 15px;
+}
+
+#code-table {
+    margin-left: -10px;
 }
 
 .table > tbody > tr.active > td.message-text {

--- a/coda-prototype/css/style.css
+++ b/coda-prototype/css/style.css
@@ -193,7 +193,7 @@ div[class*=col-], #message-panel {
     position: absolute;
     bottom: 0;
     margin-bottom: 10px;
-    width: 100%;
+    width: calc(100% + 20px); /* Compensate for margin-left of child, and bootstrap margin */
 }
 
 #code-editor-panel {

--- a/coda-prototype/src/ui/editorUI.js
+++ b/coda-prototype/src/ui/editorUI.js
@@ -868,5 +868,75 @@ var codeEditorManager = {
             let newSchemeId = messageViewerManager.deleteSchemeColumn(schemeId);
             return newSchemeId;
         }
+    },
+
+    updateScheme(updatedScheme) {
+        // Update the current scheme with the scheme just uploaded
+        let oldActiveRowCodeId = $(".code-row.active").attr("codeid");
+
+        for (let [codeId, code] of tempScheme.codes.entries()) {
+            // update existing codes
+            let codeRow = $(".code-row[codeid='" + codeId + "']");
+            if (updatedScheme.codes.has(codeId)) {
+                let newCode = updatedScheme.codes.get(codeId);
+                newCode.owner = tempScheme;
+                codeRow.find(".code-input").attr("value", newCode.value);
+
+                if (newCode.shortcut.length > 0) {
+                    // don't set value to empty string, it still counts as value, fails validation and loses placeholder text
+                    codeRow.find(".shortcut-input").attr("value", String.fromCharCode(newCode.shortcut));
+                }
+
+                codeRow.find("td").attr("style", "background-color: " + (newCode.color ? newCode.color : "#ffffff"));
+                tempScheme.codes.set(codeId, newCode);
+                updatedScheme.codes.delete(codeId);
+            } else {
+                // not in the new scheme, remove row and set a new active row if necessary
+                // TODO: what was this, and why has been commented?
+                /*
+                let isActive = codeRow.hasClass("active");
+                if (isActive) {
+                    let newActiveRow = $(".code-row:last");
+                    newActiveRow.addClass("active");
+                    codeEditorManager.activeCode = newActiveRow.attr("code-id");
+                }
+                */
+
+                codeRow.remove();
+                tempScheme.codes.delete(codeId);
+            }
+        }
+
+        for (let [codeId, code] of updatedScheme.codes.entries()) {
+            // add new codes
+            code.owner = tempScheme;
+            codeEditorManager.addCodeInputRow(code.value, code.shortcut, code.color, codeId);
+            tempScheme.codes.set(codeId, code);
+        }
+
+        $("#scheme-name-input").val(updatedScheme.name);
+
+        let newActiveRowCodeId = $(".code-row.active").attr("codeid");
+        if (newActiveRowCodeId !== oldActiveRowCodeId) {
+            let newActiveRow = $(".code-row:last");
+            newActiveRow.addClass("active");
+        }
+
+        codeEditorManager.activeCode = newActiveRowCodeId;
+        codeEditorManager.updateCodePanel(tempScheme.codes.get(codeEditorManager.activeCode));
+
+        // TODO: what was this, and why has it been commented?
+        /*
+        let activeCode = tempScheme.codes.get($(".code-row.active").attr("code-id"));
+        if (activeCode) {
+            codeEditorManager.updateCodePanel(activeCode);
+        } else {
+            // make a row active and update the code panel accordingly
+            let newActiveRow = $(".code-row:last");
+            newActiveRow.addClass('active');
+            codeEditorManager.activeCode = newActiveRow.attr("code-id");
+            codeEditorManager.updateCodePanel(tempScheme.codes.get(codeEditorManager.activeCode.id));
+        }
+        */
     }
 };

--- a/coda-prototype/src/ui/editorUI.js
+++ b/coda-prototype/src/ui/editorUI.js
@@ -85,7 +85,12 @@ var codeEditorManager = {
             }
         }, 1000, false);
 
-        $("#color-pick").colorpicker({component: $("#colorpicker-trigger"), container: editorContainer});
+        $("#color-pick").colorpicker({
+            component: $("#colorpicker-trigger"),
+            container: editorContainer,
+            useAlpha: false
+        });
+
         $("#color-pick").on("changeColor", function(event) {
 
             if (state.activeEditorRow && state.activeEditorRow.length > 0) {
@@ -99,7 +104,7 @@ var codeEditorManager = {
             $("#word-textarea").find(".tag").css({"background-color": event.color.toHex()});
             logColorChange(code, event.color); // will only run every N ms in order not to flood the activity log
         });
-        $("#color-pick").on("showPicker", (event) => {
+        $("#color-pick").on("showPicker", () => {
             $(".colorpicker").offset({top: 511, left: 1080 + $("body").scrollLeft()});
         });
 
@@ -553,6 +558,8 @@ var codeEditorManager = {
             tempScheme.codes.set(newId, codeObject); // todo: fix owner when saving to parent scheme - what does this mean
         }
 
+        let oldRow = $(".code-row[codeid='" + state.activeEditorRow + "']");
+        $(oldRow).css("background-color", "#ffffff");
         state.activeEditorRow = newId;
 
         $(".code-row").each(function(i, row) {
@@ -600,6 +607,7 @@ var codeEditorManager = {
 
         row.on("click", function() {
             let oldRow = $(".code-row[codeid='" + state.activeEditorRow + "']");
+            $(oldRow).css("background-color", "#ffffff");
             oldRow.removeClass("active");
 
             state.activeEditorRow = $(this).attr("codeid");
@@ -620,7 +628,6 @@ var codeEditorManager = {
     },
 
     updateCodePanel: function(codeObj) {
-
         // todo problem when new row is added - codeObj doesn't exist yet, so can't bind the event handler for tags
         // assume called with valid codeObject
 

--- a/coda-prototype/src/ui/initUI.js
+++ b/coda-prototype/src/ui/initUI.js
@@ -735,81 +735,15 @@ function initUI(dataset) {
         console.log("Type: " + file.type);
         console.log("Size: " + file.size + " bytes");
 
-        function handleSchemeParsed(newScheme) {
+        function handleSchemeParsed(updatedScheme) {
             // If the uploaded scheme is not a new version of the scheme to be updated, fail.
-            if (newScheme.id !== tempScheme.id) {
+            if (updatedScheme.id !== tempScheme.id) {
                 console.log("ERROR: Trying to upload scheme with a wrong ID");
                 UIUtils.displayAlertAsError("Data scheme format error - wrong id");
                 return;
             }
 
-            // Update the current scheme with the scheme just uploaded
-            let oldActiveRowCodeId = $(".code-row.active").attr("codeid");
-
-            for (let [codeId, code] of tempScheme.codes.entries()) {
-                // update existing codes
-                let codeRow = $(".code-row[codeid='" + codeId + "']");
-                if (newScheme.codes.has(codeId)) {
-                    let newCode = newScheme.codes.get(codeId);
-                    newCode.owner = tempScheme;
-                    codeRow.find(".code-input").attr("value", newCode.value);
-
-                    if (newCode.shortcut.length > 0) {
-                        // don't set value to empty string, it still counts as value, fails validation and loses placeholder text
-                        codeRow.find(".shortcut-input").attr("value", String.fromCharCode(newCode.shortcut));
-                    }
-
-                    codeRow.find("td").attr("style", "background-color: " + (newCode.color ? newCode.color : "#ffffff"));
-                    tempScheme.codes.set(codeId, newCode);
-                    newScheme.codes.delete(codeId);
-                } else {
-                    // not in the new scheme, remove row and set a new active row if necessary
-                    // TODO: what was this, and why has been commented?
-                    /*
-                    let isActive = codeRow.hasClass("active");
-                    if (isActive) {
-                        let newActiveRow = $(".code-row:last");
-                        newActiveRow.addClass("active");
-                        codeEditorManager.activeCode = newActiveRow.attr("code-id");
-                    }
-                    */
-
-                    codeRow.remove();
-                    tempScheme.codes.delete(codeId);
-                }
-            }
-
-            for (let [codeId, code] of newScheme.codes.entries()) {
-                // add new codes
-                code.owner = tempScheme;
-                codeEditorManager.addCodeInputRow(code.value, code.shortcut, code.color, codeId);
-                tempScheme.codes.set(codeId, code);
-            }
-
-            $("#scheme-name-input").val(newScheme.name);
-
-            let newActiveRowCodeId = $(".code-row.active").attr("codeid");
-            if (newActiveRowCodeId !== oldActiveRowCodeId) {
-                let newActiveRow = $(".code-row:last");
-                newActiveRow.addClass("active");
-            }
-
-            codeEditorManager.activeCode = newActiveRowCodeId;
-            codeEditorManager.updateCodePanel(tempScheme.codes.get(codeEditorManager.activeCode));
-
-            // TODO: what was this, and why has it been commented?
-            /*
-            let activeCode = tempScheme.codes.get($(".code-row.active").attr("code-id"));
-            if (activeCode) {
-                codeEditorManager.updateCodePanel(activeCode);
-            } else {
-                // make a row active and update the code panel accordingly
-                let newActiveRow = $(".code-row:last");
-                newActiveRow.addClass('active');
-                codeEditorManager.activeCode = newActiveRow.attr("code-id");
-                codeEditorManager.updateCodePanel(tempScheme.codes.get(codeEditorManager.activeCode.id));
-            }
-            */
+            codeEditorManager.updateScheme(updatedScheme);
 
             UIUtils.displayAlertAsSuccess("<strong>Success!</strong> Coding scheme was updated.");
 

--- a/coda-prototype/src/ui/initUI.js
+++ b/coda-prototype/src/ui/initUI.js
@@ -754,7 +754,7 @@ function initUI(dataset) {
                     newCode.owner = tempScheme;
                     codeRow.find(".code-input").attr("value", newCode.value);
 
-                    if (newCode.length > 0) {
+                    if (newCode.shortcut.length > 0) {
                         // don't set value to empty string, it still counts as value, fails validation and loses placeholder text
                         codeRow.find(".shortcut-input").attr("value", String.fromCharCode(newCode.shortcut));
                     }

--- a/coda-prototype/ui.html
+++ b/coda-prototype/ui.html
@@ -344,6 +344,7 @@ SOFTWARE.
                     <tr class="row">
                         <th class="col-md-6">Code</th>
                         <th class="col-md-6">Shortcut</th>
+                        <th></th>
                     </tr>
                     </thead>
                     <tbody>


### PR DESCRIPTION
Fixes shortcuts not loading into the editor correctly (#89).

Also makes the following style improvements:
- Fixes the left edge of code editor rows staying highlighted on deselect.
- Properly aligns the left edges of the editor content.
- Aligns the delete scheme button with the right edge of the editor
- Extends the border underneath the code table to stretch the full width of the table.